### PR TITLE
Use the auth guard configured for nova instead of default guard

### DIFF
--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -63,7 +63,12 @@ class Note extends Model
     {
         if (Gate::has('delete-nova-note')) return Gate::check('delete-nova-note', $this);
 
-        $user = Auth::guard(config('nova.guard'))->user();
+        if (config()->has('nova.guard')) {
+            $user = Auth::guard(config('nova.guard'))->user();
+        } else {
+            $user = Auth::user();
+        }
+        
         if (empty($user)) return false;
 
         $createdBy = $this->createdBy;

--- a/src/Models/Note.php
+++ b/src/Models/Note.php
@@ -63,7 +63,7 @@ class Note extends Model
     {
         if (Gate::has('delete-nova-note')) return Gate::check('delete-nova-note', $this);
 
-        $user = Auth::user();
+        $user = Auth::guard(config('nova.guard'))->user();
         if (empty($user)) return false;
 
         $createdBy = $this->createdBy;


### PR DESCRIPTION
The getCanDeleteAttribute() method retrieves the authenticated user with the default guard instead of using the guard configured for nova. 